### PR TITLE
Allow building without throwing exceptions internally

### DIFF
--- a/src/main/cpp/JavaExceptionUtils.cpp
+++ b/src/main/cpp/JavaExceptionUtils.cpp
@@ -30,12 +30,15 @@ namespace jni {
 
 static const size_t kExceptionMaxLength = 512;
 
-void JavaExceptionUtils::checkException(JNIEnv *env) {
+void JavaExceptionUtils::checkException(JNIEnv *env, bool clear) {
   if (env->ExceptionCheck()) {
     env->ExceptionDescribe();
 #if TERMINATE_ON_EXCEPTION
     std::terminate();
 #endif
+  }
+  if (clear) {
+    env->ExceptionClear();
   }
 }
 

--- a/src/main/cpp/JavaExceptionUtils.cpp
+++ b/src/main/cpp/JavaExceptionUtils.cpp
@@ -76,16 +76,19 @@ void JavaExceptionUtils::throwExceptionOfType(JNIEnv *env, const char *exception
   jclass clazz = JavaClassUtils::findClass(env, exception_class_name, false);
   checkException(env);
   if (clazz == NULL) {
+#if ENABLE_EXCEPTIONS
     std::stringstream fatalErrorMessage;
     fatalErrorMessage << "Could not throw exception of type '" << exception_class_name << "'";
     env->FatalError(fatalErrorMessage.str().c_str());
+#endif
     return;
   }
-
   char exceptionMessage[kExceptionMaxLength];
   vsnprintf(exceptionMessage, kExceptionMaxLength, message, arguments);
   LOG_ERROR("Throwing exception %s: %s", exception_class_name, exceptionMessage);
+#if ENABLE_EXCEPTIONS
   env->ThrowNew(clazz, exceptionMessage);
+#endif
 }
 
 void JavaExceptionUtils::throwExceptionOfType(JNIEnv *env, const char *exception_class_name, const char *message, ...) {

--- a/src/main/cpp/JavaExceptionUtils.cpp
+++ b/src/main/cpp/JavaExceptionUtils.cpp
@@ -30,16 +30,18 @@ namespace jni {
 
 static const size_t kExceptionMaxLength = 512;
 
-void JavaExceptionUtils::checkException(JNIEnv *env, bool clear) {
+void JavaExceptionUtils::checkException(JNIEnv *env) {
   if (env->ExceptionCheck()) {
     env->ExceptionDescribe();
 #if TERMINATE_ON_EXCEPTION
     std::terminate();
 #endif
   }
-  if (clear) {
-    env->ExceptionClear();
-  }
+}
+
+void JavaExceptionUtils::checkExceptionAndClear(JNIEnv *env) {
+  checkException(env);
+  env->ExceptionClear();
 }
 
 JniLocalRef<jobject> JavaExceptionUtils::newThrowable(JNIEnv *env, const char *message, ...) {

--- a/src/main/cpp/JavaExceptionUtils.h
+++ b/src/main/cpp/JavaExceptionUtils.h
@@ -38,7 +38,8 @@ private:
 public:
   static EXPORT JniLocalRef<jobject> newThrowable(JNIEnv *env, const char *message, ...);
 
-  static EXPORT void checkException(JNIEnv *env, bool clear = false);
+  static EXPORT void checkException(JNIEnv *env);
+  static EXPORT void checkExceptionAndClear(JNIEnv *env);
   static EXPORT void throwException(JNIEnv *env, const char *message, ...);
   static EXPORT void throwRuntimeException(JNIEnv *env, const char *message, ...);
   static EXPORT void throwExceptionOfType(JNIEnv *env, const char *exception_class_name, const char *message, ...);

--- a/src/main/cpp/JavaExceptionUtils.h
+++ b/src/main/cpp/JavaExceptionUtils.h
@@ -38,7 +38,7 @@ private:
 public:
   static EXPORT JniLocalRef<jobject> newThrowable(JNIEnv *env, const char *message, ...);
 
-  static EXPORT void checkException(JNIEnv *env);
+  static EXPORT void checkException(JNIEnv *env, bool clear = false);
   static EXPORT void throwException(JNIEnv *env, const char *message, ...);
   static EXPORT void throwRuntimeException(JNIEnv *env, const char *message, ...);
   static EXPORT void throwExceptionOfType(JNIEnv *env, const char *exception_class_name, const char *message, ...);

--- a/src/main/cpp/JniGlobalRef.h
+++ b/src/main/cpp/JniGlobalRef.h
@@ -42,16 +42,17 @@ class EXPORT JniGlobalRef {
   JniType get() const { return _obj; }
 
   void set(JniType obj) {
-    JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
-    if (!env) {
-      _obj = NULL;
-      return;
+    JNIEnv *env = NULL;
+    if (_obj || obj) {
+      env = JavaThreadUtils::getEnvForCurrentThread();
     }
     if (_obj) {
-      env->DeleteGlobalRef(_obj);
+      if (env) {
+        env->DeleteGlobalRef(_obj);
+      }
       _obj = NULL;
     }
-    if (obj) {
+    if (obj && env) {
       _obj = (JniType)env->NewGlobalRef(obj);
     }
   }

--- a/src/main/cpp/JniHelpersCommon.h
+++ b/src/main/cpp/JniHelpersCommon.h
@@ -73,18 +73,32 @@
 #define ENABLE_LOGGING 0
 #endif
 
+// Determines whether debug/info logging messages will be printed by JniHelpers
+#ifndef ENABLE_LOGGING_DEBUG
+#define ENABLE_LOGGING_DEBUG 0
+#endif
+
 #if ENABLE_LOGGING
 #if ANDROID
 #include <android/log.h>
 #define LOGGING_TAG "JniHelpers"
-
+#if ENABLE_LOGGING_DEBUG
 #define LOG_DEBUG(...) __android_log_print(ANDROID_LOG_INFO, LOGGING_TAG, __VA_ARGS__)
 #define LOG_INFO(...) __android_log_print(ANDROID_LOG_INFO, LOGGING_TAG, __VA_ARGS__)
+#else
+#define LOG_DEBUG(...)
+#define LOG_INFO(...)
+#endif
 #define LOG_WARN(...) __android_log_print(ANDROID_LOG_WARN, LOGGING_TAG, __VA_ARGS__)
 #define LOG_ERROR(...) __android_log_print(ANDROID_LOG_ERROR, LOGGING_TAG, __VA_ARGS__)
 #else
+#if ENABLE_LOGGING_DEBUG
 #define LOG_DEBUG(...) fprintf(stderr, "DEBUG: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")
 #define LOG_INFO(...) fprintf(stderr, "INFO: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")
+#else
+#define LOG_DEBUG(...)
+#define LOG_INFO(...)
+#endif
 #define LOG_WARN(...) fprintf(stderr, "WARN: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")
 #define LOG_ERROR(...) fprintf(stderr, "ERROR: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")
 #endif

--- a/src/main/cpp/JniHelpersCommon.h
+++ b/src/main/cpp/JniHelpersCommon.h
@@ -63,6 +63,11 @@
 #define DEBUG _DEBUG
 #endif
 
+// Determines whether exceptions will be raised by JniHelpers
+#ifndef ENABLE_EXCEPTIONS
+#define ENABLE_EXCEPTIONS 1
+#endif
+
 // Determines whether logging messages will be printed by JniHelpers
 #ifndef ENABLE_LOGGING
 #define ENABLE_LOGGING 0

--- a/src/main/cpp/JniHelpersCommon.h
+++ b/src/main/cpp/JniHelpersCommon.h
@@ -75,7 +75,11 @@
 
 // Determines whether debug/info logging messages will be printed by JniHelpers
 #ifndef ENABLE_LOGGING_DEBUG
+#ifdef DEBUG
+#define ENABLE_LOGGING_DEBUG 1
+#else
 #define ENABLE_LOGGING_DEBUG 0
+#endif
 #endif
 
 #if ENABLE_LOGGING

--- a/src/main/cpp/JniLocalRef.h
+++ b/src/main/cpp/JniLocalRef.h
@@ -35,16 +35,20 @@ public:
   JniLocalRef() : _obj(NULL) {}
   JniLocalRef(JniType obj) : _obj(NULL) { set(obj); }
   JniLocalRef(const JniLocalRef<JniType> &ref) : _obj(NULL) {
-    JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
-    set((JniType)env->NewLocalRef(ref.get()));
+    if (ref.get()) {
+      JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
+      set(env ? (JniType)env->NewLocalRef(ref.get()): NULL);
+    }
   }
 
   ~JniLocalRef() { set(NULL); }
 
   JniType get() const { return _obj; }
   void set(JniType obj) {
-    JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
-    if (_obj) env->DeleteLocalRef(_obj);
+    if (_obj) {
+      JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
+      if (env) env->DeleteLocalRef(_obj);
+    }
     _obj = obj;
   }
 
@@ -58,8 +62,13 @@ public:
 
   void operator=(JniType obj) { set(obj); }
   void operator=(const JniLocalRef<JniType> &ref) {
-    JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
-    set((JniType)env->NewLocalRef(ref.get()));
+    if (ref.get()) {
+      JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
+      set(env ? (JniType)env->NewLocalRef(ref.get()) : NULL);
+    }
+    else {
+      set(NULL);
+    }
   }
 
 private:

--- a/src/main/cpp/JniWeakGlobalRef.h
+++ b/src/main/cpp/JniWeakGlobalRef.h
@@ -48,16 +48,17 @@ class EXPORT JniWeakGlobalRef {
   }
 
   void set(JniType obj) {
-    JNIEnv *env = JavaThreadUtils::getEnvForCurrentThread();
-    if (!env) {
-        _obj = NULL;
-        return;
+    JNIEnv *env = NULL;
+    if (_obj || obj) {
+      env = JavaThreadUtils::getEnvForCurrentThread();
     }
     if (_obj) {
-      env->DeleteGlobalRef(_obj);
+      if (env) {
+        env->DeleteGlobalRef(_obj);
+      }
       _obj = NULL;
     }
-    if (obj) {
+    if (obj && env) {
       _obj = (JniType)env->NewWeakGlobalRef(obj);
     }
   }


### PR DESCRIPTION
Make exceptions options with build flag (default on).
Separate debug/info log from warn/error log
Allow exceptions to be cleared in checkException
Refactor in ref classes to avoid env calls when not needed
